### PR TITLE
Automatic parameter sweeps

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ To decode an FEC encoded file and apply the erasure and error correcting codes:
     └── data
 ```
 
-## System Tests
+## Testing
+
+**Note:** these test scripts require Python 3.6 or higher.
 
 To run the system tests first you'll need to compile the project with `DXWIFI_TESTS` defined.
 The project Cmake file defines two build configurations with this macro enabled, `TestDebug` and `TestRel`.
@@ -199,6 +201,18 @@ packetized data from a `savefile`. With the correct binaries built, simply run t
 ```
 python -m unittest
 ```
+
+There is also a script `sweep.py` to automatically iterate through code rate, error rate, and packet loss rate parameters. To use (from the repository root):
+
+```
+python test/sweep.py  --code-rate   | -c [min] [max] [step]
+                      --error-rate  | -e [min] [max] [step]
+                      --packet-loss | -p [min] [max] [step]
+                      --source      | -s [source file path]
+                      --output      | -o [output directory path]
+```
+
+This will perform all combinations of code rates, error rates, and packet loss rates (offline) and save the outputs in subdirectories in the specified output directory.
 
 ## Cross Compilation
 

--- a/dxwifi/tx/tx.c
+++ b/dxwifi/tx/tx.c
@@ -1,10 +1,10 @@
 /**
  *  tx.c
- * 
+ *
  *  DESCRIPTION: DxWiFi Transmission program
- * 
+ *
  *  https://github.com/oresat/oresat-dxwifi-software
- * 
+ *
  */
 
 #include <stdio.h>
@@ -52,7 +52,7 @@ int main(int argc, char** argv) {
     transmitter = &args.tx;
 
     parse_args(argc, argv, &args);
-    
+
     set_log_level(DXWIFI_LOG_ALL_MODULES, args.verbosity);
 
     if(args.use_syslog) {
@@ -81,11 +81,11 @@ int main(int argc, char** argv) {
 /**
  *  DESCRIPTION:    SIGTERM handler for daemonized process. Ensures transmitter
  *                  is closed.
- * 
- *  ARGUMENTS: 
- *      
- *      signum:     Received signal  
- * 
+ *
+ *  ARGUMENTS:
+ *
+ *      signum:     Received signal
+ *
  */
 void terminate(int signum) {
     stop_transmission(transmitter);
@@ -96,11 +96,11 @@ void terminate(int signum) {
 
 /**
  *  DESCRIPTION:    Signals to the transmitter to stop transmission
- * 
- *  ARGUMENTS: 
- *      
- *      signum:     Received signal  
- * 
+ *
+ *  ARGUMENTS:
+ *
+ *      signum:     Received signal
+ *
  */
 void tx_sigint_handler(int signum) {
     stop_transmission(transmitter);
@@ -109,11 +109,11 @@ void tx_sigint_handler(int signum) {
 
 /**
  *  DESCRIPTION:    Signals to the watch loop to close out
- * 
- *  ARGUMENTS: 
- *      
- *      signum:     Received signal  
- * 
+ *
+ *  ARGUMENTS:
+ *
+ *      signum:     Received signal
+ *
  */
 void watchdir_sigint_handler(int signum) {
     dirwatch_stop(dirwatch_handle);
@@ -122,11 +122,11 @@ void watchdir_sigint_handler(int signum) {
 
 /**
  *  DESCRIPTION:    Log info about the transmitted file
- * 
- *  ARGUMENTS: 
- *      
+ *
+ *  ARGUMENTS:
+ *
  *      stats:      Accumulated statistics about the transmission
- * 
+ *
  */
 void log_tx_stats(dxwifi_tx_stats stats) {
     log_debug(
@@ -144,13 +144,13 @@ void log_tx_stats(dxwifi_tx_stats stats) {
 
 
 /**
- *  DESCRIPTION:    Called everytime a frame is injected, logs stats about the 
+ *  DESCRIPTION:    Called everytime a frame is injected, logs stats about the
  *                  transmitted frame.
- * 
- *  ARGUMENTS: 
- * 
+ *
+ *  ARGUMENTS:
+ *
  *      See definition of dxwifi_tx_frame_cb in transmitter.h
- * 
+ *
  */
 void log_frame_stats(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* user) {
     if(stats.frame_type == DXWIFI_CONTROL_FRAME_NONE) {
@@ -164,13 +164,13 @@ void log_frame_stats(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* user) 
 
 
 /**
- *  DESCRIPTION:    Called before every frame is injected, adds millisecond 
+ *  DESCRIPTION:    Called before every frame is injected, adds millisecond
  *                  delay to transmission
- * 
- *  ARGUMENTS: 
- * 
+ *
+ *  ARGUMENTS:
+ *
  *      See definition of dxwifi_tx_frame_cb in transmitter.h
- * 
+ *
  */
 void delay_transmission(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* user) {
     unsigned delay_ms = *(unsigned*) user;
@@ -179,20 +179,20 @@ void delay_transmission(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* use
 }
 
 /**
- *  DESCRIPTION:    Called before every frame is injected, will intentionally 
+ *  DESCRIPTION:    Called before every frame is injected, will intentionally
  *                  drop packets according to packet loss rate
- * 
- *  ARGUMENTS: 
- * 
- *      packet_loss_rate:        Float percentage of packets lost   
- * 
+ *
+ *  ARGUMENTS:
+ *
+ *      packet_loss_rate:        Float percentage of packets lost
+ *
  */
 void packet_loss_sim(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* user) {
     packet_loss_stats * plstats = (packet_loss_stats*) user;
     //generate random num withing range
     float random = (float)rand() / (float)RAND_MAX;
-    
-    if(plstats->packet_loss_rate < random){
+
+    if(plstats->packet_loss_rate > random){
         frame->payload_size = 0;
         plstats->count++;
     }
@@ -200,20 +200,20 @@ void packet_loss_sim(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* user) 
 }
 
 /**
- *  DESCRIPTION:    Called before every frame is injected, will intentionally 
+ *  DESCRIPTION:    Called before every frame is injected, will intentionally
  *                  flip bits in according to error rate
- * 
- *  ARGUMENTS: 
- * 
+ *
+ *  ARGUMENTS:
+ *
  *     error_rate:      Float percentage of bits flipped
- * 
+ *
  */
 void bit_error_rate_sim(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* user) {
     float error_rate = *(float*) user;
     int frame_size = DXWIFI_TX_HEADER_SIZE + frame->payload_size + IEEE80211_FCS_SIZE;
     int total_num_errors = frame_size * 8 * error_rate; //Get total number of errors
     uint8_t bit_array[frame_size]; //Make an array of bits equal to the number in the frame
-    
+
     // Initialize every bit to zero
     memset(bit_array, 0, frame_size);
 
@@ -234,14 +234,14 @@ void bit_error_rate_sim(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* use
 }
 
 /**
- *  DESCRIPTION:    Called before every frame is injected, packs the current 
- *                  frame count into the last four bytes of the MAC headers 
+ *  DESCRIPTION:    Called before every frame is injected, packs the current
+ *                  frame count into the last four bytes of the MAC headers
  *                  addr1 field
- * 
- *  ARGUMENTS: 
- * 
+ *
+ *  ARGUMENTS:
+ *
  *      See definition of dxwifi_tx_frame_cb in transmitter.h
- * 
+ *
  */
 void attach_frame_number(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* user) {
     uint32_t frame_no = htonl(stats.data_frame_count);
@@ -252,13 +252,13 @@ void attach_frame_number(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* us
 
 /**
  *  DESCRIPTION:    Setups and tearsdown SIGINT handlers to control transmission
- * 
- *  ARGUMENTS: 
- *      
+ *
+ *  ARGUMENTS:
+ *
  *      tx:         Initialized transmitter
- * 
+ *
  *      fd:         Opened file descriptor of the file to be transmitted
- * 
+ *
  */
 dxwifi_tx_state_t setup_handlers_and_transmit(dxwifi_transmitter* tx, int fd) {
     dxwifi_tx_stats stats;
@@ -279,26 +279,26 @@ dxwifi_tx_state_t setup_handlers_and_transmit(dxwifi_transmitter* tx, int fd) {
 
 
 /**
- *  DESCRIPTION:    Iterates through a list of file names, opens them, and 
+ *  DESCRIPTION:    Iterates through a list of file names, opens them, and
  *                  transmits them
- * 
- *  ARGUMENTS: 
- *      
+ *
+ *  ARGUMENTS:
+ *
  *      tx:         Initialized transmitter
- * 
+ *
  *      files:      List of files to transmit
- * 
- *      delay:      Millisecond delay to add between file transmission. 
- * 
+ *
+ *      delay:      Millisecond delay to add between file transmission.
+ *
  *      retransmit_count:
  *                  Number of times to retransmit the file. If the count is -1
- *                  then the file will be retransmitted forever or until the 
+ *                  then the file will be retransmitted forever or until the
  *                  transmitter reports a timeout or error
- * 
+ *
  *  RETURNS:
- *      
+ *
  *      dxwifi_tx_state_t: The last reported state of the transmitter
- * 
+ *
  */
 dxwifi_tx_state_t transmit_files(dxwifi_transmitter* tx, char** files, size_t num_files, unsigned delay, int retransmit_count) {
     int fd = 0;
@@ -335,17 +335,17 @@ dxwifi_tx_state_t transmit_files(dxwifi_transmitter* tx, char** files, size_t nu
 
 /**
  *  DESCRIPTION:    Transmit all files in a directory that matches a filter
- * 
- *  ARGUMENTS: 
- *      
+ *
+ *  ARGUMENTS:
+ *
  *      tx:         Initialized transmitter
- * 
+ *
  *      filter:     Glob pattern to filter which files should be transmitted
- * 
+ *
  *      dirname:    Name of target directory
- * 
+ *
  *      delay:      Inter-file transmission delay in milliseconds
- * 
+ *
  */
 void transmit_directory_contents(dxwifi_transmitter* tx, const char* filter, const char* dirname, unsigned delay, int retransmit_count) {
     DIR* dir;
@@ -373,13 +373,13 @@ void transmit_directory_contents(dxwifi_transmitter* tx, const char* filter, con
 
 /**
  *  DESCRIPTION:    Dirwatch callback, transmits newly created file
- * 
- *  ARGUMENTS: 
- *      
+ *
+ *  ARGUMENTS:
+ *
  *      event:      Creation and close event
- * 
+ *
  *      user:       Command line arguments
- * 
+ *
  */
 static void transmit_new_file(const dirwatch_event* event, void* user) {
     cli_args* args = (cli_args*) user;
@@ -397,13 +397,13 @@ static void transmit_new_file(const dirwatch_event* event, void* user) {
 /**
  *  DESCRIPTION:    Transmits current directory contents and listens for newly
  *                  created files to transmit
- * 
- *  ARGUMENTS: 
- *      
+ *
+ *  ARGUMENTS:
+ *
  *      args:       Parsed command line arguments
- * 
+ *
  *      tx:         Initialized transmitter
- * 
+ *
  */
 void transmit_directory(cli_args* args, dxwifi_transmitter* tx) {
 
@@ -436,16 +436,16 @@ void transmit_directory(cli_args* args, dxwifi_transmitter* tx) {
 
 
 /**
- *  DESCRIPTION:    Transmit a test sequence of bytes. The test sequence is a 
- *                  10Kb block of data with the transmission count encoded in 
+ *  DESCRIPTION:    Transmit a test sequence of bytes. The test sequence is a
+ *                  10Kb block of data with the transmission count encoded in
  *                  every four bytes as the payload
- * 
- *  ARGUMENTS: 
- *      
+ *
+ *  ARGUMENTS:
+ *
  *      tx:         Initialized transmitter
- * 
+ *
  *      retransmit: Number of times to transmit test sequence
- * 
+ *
  */
 void transmit_test_sequence(dxwifi_transmitter* tx, int retransmit) {
 
@@ -478,13 +478,13 @@ void transmit_test_sequence(dxwifi_transmitter* tx, int retransmit) {
 
 /**
  *  DESCRIPTION:    Determine the transmission mode and transmit files
- * 
- *  ARGUMENTS: 
- *      
+ *
+ *  ARGUMENTS:
+ *
  *      args:       Parsed command line arguments
- * 
+ *
  *      tx:         Initialized transmitter
- * 
+ *
  */
 void transmit(cli_args* args, dxwifi_transmitter* tx) {
 
@@ -525,7 +525,7 @@ void transmit(cli_args* args, dxwifi_transmitter* tx) {
     case TX_TEST_MODE:
         transmit_test_sequence(tx, args->retransmit_count);
         break;
-    
+
     default:
         break;
     }

--- a/test/sweep.py
+++ b/test/sweep.py
@@ -1,0 +1,102 @@
+'''
+    FILE: sweep.py
+
+    DESCRIPTION: Automatically run through FEC and error parameters.
+
+    NOTES: This script only works with the `TestDebug` and `TestRel`
+    configurations. By default, it will assume the binaries are
+    installed in `bin/TestDebug`. If they are installed elsewhere
+    please define the `DXWIFI_INSTALL_DIR` environment variable with
+    the correct install location.
+'''
+
+# Imports
+import os
+import sys
+import shutil
+import argparse
+import subprocess
+import numpy as np
+
+# Generate inclusive arange list from given parameters
+def inclusive_arange(start, stop, step):
+    return np.arange(start, stop + step / 10, step, dtype = np.float64)
+
+# Get binary paths
+INSTALL_DIR = os.environ.get('DXWIFI_INSTALL_DIR', default='bin/TestDebug')
+TX = f'./{INSTALL_DIR}/tx'
+RX = f'./{INSTALL_DIR}/rx'
+ENCODE = f'./{INSTALL_DIR}/encode'
+DECODE = f'./{INSTALL_DIR}/decode'
+
+# Verify binaries exist
+if not all([os.access(binary, os.X_OK) for binary in (TX, RX, ENCODE, DECODE)]):
+    print(f"Error! Please verify all programs available at {INSTALL_DIR}.")
+    sys.exit(1)
+
+# Parse arguments
+metavar_names = ("MIN", "MAX", "STEP")
+parser = argparse.ArgumentParser(description = "Automatically sweep through FEC / error parameters.")
+parser.add_argument("--code-rate", "-c", type = float, nargs = 3, required = True,
+                    help = "FEC code rate", metavar = metavar_names)
+parser.add_argument("--error-rate", "-e", type = float, nargs = 3, required = True,
+                    help = "bit error rate", metavar = metavar_names)
+parser.add_argument("--packet-loss", "-p", type = float, nargs = 3, required = True,
+                    help = "packet loss", metavar = metavar_names)
+parser.add_argument("--source", "-s", required = True, help = "source file path")
+parser.add_argument("--output", "-o", required = True, help = "output directory path")
+args = parser.parse_args()
+
+# Generate sweep lists
+code_rates = inclusive_arange(*args.code_rate)
+error_rates = inclusive_arange(*args.error_rate)
+packet_losses = inclusive_arange(*args.packet_loss)
+
+# Make (or overwrite) the output directory
+if os.path.exists(args.output):
+    shutil.rmtree(args.output)
+os.mkdir(args.output)
+
+# Iterate over code rates
+for cr in code_rates:
+
+    # Make a directory for this code rate
+    cr_dir = os.path.join(args.output, f"CodeRate{cr}")
+    os.mkdir(cr_dir)
+
+    # Perform encoding
+    cr_output = os.path.join(cr_dir, "file.encoded")
+    encode_command = f"{ENCODE} {args.source} -o {cr_output} -c {cr}"
+    with open(os.path.join(cr_dir, "encode_output.txt"), "w") as f:
+        subprocess.run(encode_command.split(), stdout = f, stderr = f)
+
+    # Iterate over error rates
+    for er in error_rates:
+
+        # Iterate over packet losses
+        for pl in packet_losses:
+
+            # Make a directory for this combination
+            er_pl_dir = os.path.join(cr_dir, f"ErrorRate{er}_PacketLoss{pl}")
+            os.mkdir(er_pl_dir)
+
+            # Perform "transmission"
+            tx_output = os.path.join(er_pl_dir, "file.sent")
+            tx_command = f"{TX} -e {er} -p {pl} --savefile {tx_output} {cr_output}"
+            with open(os.path.join(er_pl_dir, "tx_output.txt"), "w") as f:
+                subprocess.run(tx_command.split(), stdout = f, stderr = f)
+
+            # Perform "reception"
+            rx_output = os.path.join(er_pl_dir, "file.received")
+            rx_command = f"{RX} --savefile {tx_output} {rx_output}"
+            with open(os.path.join(er_pl_dir, "rx_output.txt"), "w") as f:
+                subprocess.run(rx_command.split(), stdout = f, stderr = f)
+
+            # Perform decoding
+            decode_output = os.path.join(er_pl_dir, "file.decoded")
+            decode_command = f"{DECODE} {rx_output} -o {decode_output}"
+            with open(os.path.join(er_pl_dir, "decode_output.txt"), "w") as f:
+                subprocess.run(decode_command.split(), stdout = f, stderr = f)
+
+            # Notify user
+            print(f"Finished packet loss rate {pl} for error rate {er} with code rate {cr}.")

--- a/test/sweep.py
+++ b/test/sweep.py
@@ -48,9 +48,10 @@ parser.add_argument("--output", "-o", required = True, help = "output directory 
 args = parser.parse_args()
 
 # Generate sweep lists
-code_rates = inclusive_arange(*args.code_rate)
-error_rates = inclusive_arange(*args.error_rate)
-packet_losses = inclusive_arange(*args.packet_loss)
+fix_fp = lambda x: np.round(x, 2)
+code_rates = fix_fp(inclusive_arange(*args.code_rate))
+error_rates = fix_fp(inclusive_arange(*args.error_rate))
+packet_losses = fix_fp(inclusive_arange(*args.packet_loss))
 
 # Make (or overwrite) the output directory
 if os.path.exists(args.output):
@@ -61,7 +62,7 @@ os.mkdir(args.output)
 for cr in code_rates:
 
     # Make a directory for this code rate
-    cr_dir = os.path.join(args.output, f"CodeRate{cr}")
+    cr_dir = os.path.join(args.output, f"CodeRate{cr:.2f}")
     os.mkdir(cr_dir)
 
     # Perform encoding
@@ -77,7 +78,7 @@ for cr in code_rates:
         for pl in packet_losses:
 
             # Make a directory for this combination
-            er_pl_dir = os.path.join(cr_dir, f"ErrorRate{er}_PacketLoss{pl}")
+            er_pl_dir = os.path.join(cr_dir, f"ErrorRate{er:.2f}_PacketLoss{pl:.2f}")
             os.mkdir(er_pl_dir)
 
             # Perform "transmission"
@@ -99,4 +100,4 @@ for cr in code_rates:
                 subprocess.run(decode_command.split(), stdout = f, stderr = f)
 
             # Notify user
-            print(f"Finished packet loss rate {pl} for error rate {er} with code rate {cr}.")
+            print(f"Finished packet loss rate {pl:.2f} for error rate {er:.2f} with code rate {cr:.2f}.")

--- a/test/sweep.py
+++ b/test/sweep.py
@@ -16,11 +16,13 @@ import sys
 import shutil
 import argparse
 import subprocess
-import numpy as np
 
-# Generate inclusive arange list from given parameters
-def inclusive_arange(start, stop, step):
-    return np.arange(start, stop + step / 10, step, dtype = np.float64)
+# Generate inclusive float range list from given parameters
+def make_range(start, stop, step):
+    shift = int(1 / step)
+    int_params = [int(i * shift) for i in (start, stop, step)]
+    int_params[1] += 1
+    return [i / shift for i in range(*int_params)]
 
 # Get binary paths
 INSTALL_DIR = os.environ.get('DXWIFI_INSTALL_DIR', default='bin/TestDebug')
@@ -48,10 +50,9 @@ parser.add_argument("--output", "-o", required = True, help = "output directory 
 args = parser.parse_args()
 
 # Generate sweep lists
-fix_fp = lambda x: np.round(x, 2)
-code_rates = fix_fp(inclusive_arange(*args.code_rate))
-error_rates = fix_fp(inclusive_arange(*args.error_rate))
-packet_losses = fix_fp(inclusive_arange(*args.packet_loss))
+code_rates = make_range(*args.code_rate)
+error_rates = make_range(*args.error_rate)
+packet_losses = make_range(*args.packet_loss)
 
 # Make (or overwrite) the output directory
 if os.path.exists(args.output):


### PR DESCRIPTION
Closes #20.

To use (from the repository root):

```
python test/sweep.py  -c [min] [max] [step] -e [min] [max] [step] -p [min] [max] [step] -s [source file] -o [output directory]
```

This will perform combinations of code rates, error rates, and packet loss rates and save the outputs in subdirectories in the specified output directory.

I'm pretty sure this is working -- however, I am not 100% on this because I've faced some nonintuitive behavior with `tx` and `rx`. If I use a packet loss rate of `0.02`, for example, pretty much the entire transmission seems to be lost. In fact, running `rx` on the output returns 0 bytes, which in turn causes a decoding error.

I am not sure if this is a result of blocksize or if there are problems in the error implementations. But I feel like we should be able to handle 2% packet loss, right? Everyone please pull this branch and test things out before proceeding.