### PR TITLE
Bugfixes

### DIFF
--- a/dxwifi/rx/rx.c
+++ b/dxwifi/rx/rx.c
@@ -26,7 +26,7 @@
 #include <libdxwifi/details/syslogger.h>
 
 
-#define RX_TEMP_FILE "./rx.raw"
+#define RX_TEMP_FILE "/tmp/rx.raw"
 
 
 dxwifi_receiver* receiver = NULL;
@@ -151,17 +151,51 @@ dxwifi_rx_state_t setup_handlers_and_capture(dxwifi_receiver* rx, int fd) {
  * 
  */
 dxwifi_rx_state_t open_file_and_capture(const char* path, dxwifi_receiver* rx, bool append) {
-    int fd          = 0;
-    int open_flags  = O_WRONLY | O_CREAT | (append ? O_APPEND : 0);
-    mode_t mode     = S_IRUSR  | S_IWUSR | S_IROTH | S_IWOTH; 
+    int fd          = 0; //output file descriptor
+    int temp_fd     = 0; //temp file descriptor
 
+    int open_flags  = O_WRONLY | O_CREAT | (append ? O_APPEND : O_TRUNC);
+    mode_t mode     = S_IRUSR  | S_IWUSR | S_IROTH | S_IWOTH; 
+    
     dxwifi_rx_state_t state = DXWIFI_RX_ERROR;
-    if((fd = open(path, open_flags, mode)) < 0) {
-        log_error("Failed to open file: %s", path);
+
+    if((temp_fd = creat(RX_TEMP_FILE, mode)) < 0) {
+        log_error("Failed to open temp file for capture");
     }
     else {
-        state = setup_handlers_and_capture(rx, fd);
-        close(fd);
+
+        state = setup_handlers_and_capture(rx, temp_fd);
+        off_t temp_file_size = get_file_size(RX_TEMP_FILE);
+        
+        //Map the encoded file to memory
+        void* encoded_data = mmap(NULL, temp_file_size, PROT_WRITE, MAP_SHARED, temp_fd, 0);
+        assert_M(encoded_data != MAP_FAILED, "Failed to map file to memory - %s", strerror(errno));
+        
+        if(state != DXWIFI_RX_ERROR) {
+            if((fd = open(path, open_flags, mode)) < 0) {
+                log_error("Failed to open file: %s", path);
+            }
+            else {
+
+                void *decoded_message = NULL;
+                size_t decoded_size = dxwifi_decode(encoded_data, temp_file_size, &decoded_message);
+
+                if(decoded_size > 0) {
+                    log_info("Decoding Success for RX'd file, File Size: %d", decoded_size);
+
+                    ssize_t nbytes = write(fd, decoded_message, decoded_size);
+                    assert_M(decoded_size == nbytes, "Partial write occured: %d/%d - %s", nbytes, decoded_size, strerror(errno));
+                    free(decoded_message);
+                }
+                else{
+                    log_error("Failed to Decode Rx'd file, Error: %s", dxwifi_fec_error_to_str(decoded_size));
+                }
+                close(fd);
+            }
+        }
+        close(temp_fd);
+        remove(RX_TEMP_FILE);
+        munmap(encoded_data, temp_file_size);
     }
     return state;
 }
@@ -219,5 +253,4 @@ void receive(cli_args* args, dxwifi_receiver* rx) {
     default:
         break;
     }
-
 }

--- a/dxwifi/rx/rx.c
+++ b/dxwifi/rx/rx.c
@@ -182,7 +182,7 @@ dxwifi_rx_state_t open_file_and_capture(const char* path, dxwifi_receiver* rx, b
             else {
 
                 void *decoded_message = NULL;
-                size_t decoded_size = dxwifi_decode(encoded_data, temp_file_size, &decoded_message);
+                ssize_t decoded_size = dxwifi_decode(encoded_data, temp_file_size, &decoded_message);
 
                 if(decoded_size > 0) {
                     log_info("Decoding Success for RX'd file, File Size: %d", decoded_size);

--- a/dxwifi/rx/rx.c
+++ b/dxwifi/rx/rx.c
@@ -151,15 +151,16 @@ dxwifi_rx_state_t setup_handlers_and_capture(dxwifi_receiver* rx, int fd) {
  * 
  */
 dxwifi_rx_state_t open_file_and_capture(const char* path, dxwifi_receiver* rx, bool append) {
-    int fd          = 0; //output file descriptor
-    int temp_fd     = 0; //temp file descriptor
+    int fd_out      = 0;
+    int temp_fd     = 0;
 
-    int open_flags  = O_RDWR  | O_CREAT | (append ? O_APPEND : O_TRUNC);
-    mode_t mode     = S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH; 
+    int temp_flags  = O_RDWR   | O_CREAT | O_TRUNC;
+    int open_flags  = O_WRONLY | O_CREAT | (append ? O_APPEND : O_TRUNC);
+    mode_t mode     = S_IRUSR  | S_IWUSR | S_IROTH | S_IWOTH; 
     
     dxwifi_rx_state_t state = DXWIFI_RX_ERROR;
 
-    if((temp_fd = open(RX_TEMP_FILE, open_flags, mode)) < 0) {
+    if((temp_fd = open(RX_TEMP_FILE, temp_flags, mode)) < 0) {
         log_error("Failed to open temp file for capture");
     }
     else {
@@ -172,7 +173,7 @@ dxwifi_rx_state_t open_file_and_capture(const char* path, dxwifi_receiver* rx, b
         assert_M(encoded_data != MAP_FAILED, "Failed to map file to memory - %s", strerror(errno));
         
         if(state != DXWIFI_RX_ERROR) {
-            if((fd = open(path, open_flags, mode)) < 0) {
+            if((fd_out = open(path, open_flags, mode)) < 0) {
                 log_error("Failed to open file: %s", path);
             }
             else {
@@ -183,14 +184,14 @@ dxwifi_rx_state_t open_file_and_capture(const char* path, dxwifi_receiver* rx, b
                 if(decoded_size > 0) {
                     log_info("Decoding Success for RX'd file, File Size: %d", decoded_size);
 
-                    ssize_t nbytes = write(fd, decoded_message, decoded_size);
+                    ssize_t nbytes = write(fd_out, decoded_message, decoded_size);
                     assert_M(decoded_size == nbytes, "Partial write occured: %d/%d - %s", nbytes, decoded_size, strerror(errno));
                     free(decoded_message);
                 }
                 else{
                     log_error("Failed to Decode Rx'd file, Error: %s", dxwifi_fec_error_to_str(decoded_size));
                 }
-                close(fd);
+                close(fd_out);
             }
         }
         close(temp_fd);

--- a/dxwifi/rx/rx.c
+++ b/dxwifi/rx/rx.c
@@ -26,7 +26,7 @@
 #include <libdxwifi/details/syslogger.h>
 
 
-#define RX_TEMP_FILE "/tmp/rx.raw"
+#define RX_TEMP_FILE "./rx.raw"
 
 
 dxwifi_receiver* receiver = NULL;
@@ -151,55 +151,17 @@ dxwifi_rx_state_t setup_handlers_and_capture(dxwifi_receiver* rx, int fd) {
  * 
  */
 dxwifi_rx_state_t open_file_and_capture(const char* path, dxwifi_receiver* rx, bool append) {
-    int fd          = 0; //output file descriptor
-    int temp_fd     = 0; //temp file descriptor
-
+    int fd          = 0;
     int open_flags  = O_WRONLY | O_CREAT | (append ? O_APPEND : 0);
     mode_t mode     = S_IRUSR  | S_IWUSR | S_IROTH | S_IWOTH; 
-    
-    log_debug("Open File and Capture");
 
     dxwifi_rx_state_t state = DXWIFI_RX_ERROR;
-
-    if((temp_fd = open(RX_TEMP_FILE, O_RDWR | O_CREAT, mode)) < 0) {
-        log_error("Failed to open temp file for capture");
+    if((fd = open(path, open_flags, mode)) < 0) {
+        log_error("Failed to open file: %s", path);
     }
     else {
-
-        state = setup_handlers_and_capture(rx, temp_fd);
-        off_t temp_file_size = get_file_size(RX_TEMP_FILE);
-        
-        //Map the encoded file to memory
-        void* encoded_data = mmap(NULL, temp_file_size, PROT_WRITE, MAP_SHARED, temp_fd, 0);
-        assert_M(encoded_data != MAP_FAILED, "Failed to map file to memory - %s", strerror(errno));
-        
-        //If the file was transferred correctly and mapped to memory without errors...
-        if(state != DXWIFI_RX_ERROR) {
-
-            if((fd = open(path, open_flags, mode)) < 0) {
-                log_error("Failed to open file: %s", path);
-            }
-            else {
-
-                void *decoded_message = NULL;
-                ssize_t decoded_size = dxwifi_decode(encoded_data, temp_file_size, &decoded_message);
-
-                if(decoded_size > 0) {
-                    log_info("Decoding Success for RX'd file, File Size: %d", decoded_size);
-
-                    ssize_t nbytes = write(fd, decoded_message, decoded_size);
-                    assert_M(decoded_size == nbytes, "Partial write occured: %d/%d - %s", nbytes, decoded_size, strerror(errno));
-                    free(decoded_message);
-                }
-                else{
-                    log_error("Failed to Decode Rx'd file, Error: %s", dxwifi_fec_error_to_str(decoded_size));
-                }
-                close(fd);
-            }
-        }
-        close(temp_fd);
-        remove(RX_TEMP_FILE);
-        munmap(encoded_data, temp_file_size);
+        state = setup_handlers_and_capture(rx, fd);
+        close(fd);
     }
     return state;
 }

--- a/dxwifi/rx/rx.c
+++ b/dxwifi/rx/rx.c
@@ -154,12 +154,12 @@ dxwifi_rx_state_t open_file_and_capture(const char* path, dxwifi_receiver* rx, b
     int fd          = 0; //output file descriptor
     int temp_fd     = 0; //temp file descriptor
 
-    int open_flags  = O_WRONLY | O_CREAT | (append ? O_APPEND : O_TRUNC);
-    mode_t mode     = S_IRUSR  | S_IWUSR | S_IROTH | S_IWOTH; 
+    int open_flags  = O_RDWR  | O_CREAT | (append ? O_APPEND : O_TRUNC);
+    mode_t mode     = S_IRUSR | S_IWUSR | S_IROTH | S_IWOTH; 
     
     dxwifi_rx_state_t state = DXWIFI_RX_ERROR;
 
-    if((temp_fd = creat(RX_TEMP_FILE, mode)) < 0) {
+    if((temp_fd = open(RX_TEMP_FILE, open_flags, mode)) < 0) {
         log_error("Failed to open temp file for capture");
     }
     else {
@@ -178,7 +178,7 @@ dxwifi_rx_state_t open_file_and_capture(const char* path, dxwifi_receiver* rx, b
             else {
 
                 void *decoded_message = NULL;
-                size_t decoded_size = dxwifi_decode(encoded_data, temp_file_size, &decoded_message);
+                ssize_t decoded_size = dxwifi_decode(encoded_data, temp_file_size, &decoded_message);
 
                 if(decoded_size > 0) {
                     log_info("Decoding Success for RX'd file, File Size: %d", decoded_size);

--- a/dxwifi/rx/rx.c
+++ b/dxwifi/rx/rx.c
@@ -73,6 +73,7 @@ void log_rx_stats(dxwifi_rx_stats stats) {
         "\tTotal Capture Size:          %d\n"
         "\tTotal Blocks Lost:           %d\n"
         "\tTotal Noise Added:           %d\n"
+        "\tBad CRC Count:               %d\n"
         "\tPackets Processed:           %d\n"
         "\tPackets Received:            %d\n"
         "\tPackets Dropped (receiver):  %d\n"
@@ -85,6 +86,7 @@ void log_rx_stats(dxwifi_rx_stats stats) {
         stats.total_caplen,
         stats.total_blocks_lost,
         stats.total_noise_added,
+        stats.bad_crcs,
         stats.num_packets_processed,
         stats.pcap_stats.ps_recv,
         stats.packets_dropped,

--- a/dxwifi/tx/cli.h
+++ b/dxwifi/tx/cli.h
@@ -70,7 +70,7 @@ typedef struct {
         .error_rate                 = 0,\
         .packet_loss                = 0,\
         .tx                         = DXWIFI_TRANSMITTER_DFLT_INITIALIZER,\
-        .coderate                   = 0.5\
+        .coderate                   = 0.667\
     }\
 
 

--- a/dxwifi/tx/tx.c
+++ b/dxwifi/tx/tx.c
@@ -66,7 +66,13 @@ int main(int argc, char** argv) {
         signal(SIGTERM, terminate);
     }
 
-    srand(time(0)); // Seed random number generator
+#if defined(DXWIFI_TESTS)
+    unsigned seed = 1621981756;
+#else
+    unsigned seed = time(0);
+#endif
+
+    srand(seed);
 
     init_transmitter(transmitter, args.device);
 
@@ -243,6 +249,7 @@ bool bit_error_rate_sim(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* use
     log_debug("Bits in frame: %d, bits flipped: %d", frame_size * 8, total_num_errors);
     return true;
 }
+
 
 /**
  *  DESCRIPTION:    Called before every frame is injected, packs the current

--- a/dxwifi/tx/tx.c
+++ b/dxwifi/tx/tx.c
@@ -316,34 +316,47 @@ dxwifi_tx_state_t setup_handlers_and_transmit(dxwifi_transmitter* tx, int fd) {
  */
 dxwifi_tx_state_t transmit_files(dxwifi_transmitter* tx, char** files, size_t num_files, unsigned delay, int retransmit_count, float coderate) {
     int fd = 0;
-    dxwifi_tx_state_t state = DXWIFI_TX_NORMAL;
+    dxwifi_tx_stats stats = { .tx_state = DXWIFI_TX_NORMAL };
 
-    for(size_t i = 0; i < num_files && state == DXWIFI_TX_NORMAL; ++i) {
+    for(size_t i = 0; i < num_files && stats.tx_state == DXWIFI_TX_NORMAL; ++i) {
         if((fd = open(files[i], O_RDONLY)) < 0) {
             log_error("Failed to open file: %s - %s", files[i], strerror(errno));
         }
         else {
             log_info("Opened %s for transmission", files[i]);
+            off_t file_size = get_file_size(files[i]);
 
-            int count = retransmit_count;
-            bool transmit_forever = (retransmit_count == -1);
-            while((count >= 0 || transmit_forever) && state == DXWIFI_TX_NORMAL) {
-                int status = lseek(fd, 0, SEEK_SET);
+            void* file_data = mmap(NULL, file_size, PROT_READ, MAP_SHARED, fd, 0);
+            assert_M(file_data != MAP_FAILED, "Failed to map file to memory - %s", strerror(errno));
 
-                if(status == -1) {
-                    log_error("Failed to seek to beginning of file: %s", strerror(errno));
-                    state = DXWIFI_TX_ERROR;
+            void *encoded_message = NULL;
+            size_t msg_size = dxwifi_encode(file_data, file_size, coderate, &encoded_message);
+
+            if(msg_size > 0){
+
+            	log_info("Encoding Success for file: [%s], Filesize: %d", files[i], msg_size);
+
+            	int count = retransmit_count;
+
+            	bool transmit_forever = (retransmit_count == -1);
+                while((count >= 0 || transmit_forever) && stats.tx_state == DXWIFI_TX_NORMAL) {
+
+                	transmit_bytes(tx, encoded_message, msg_size, &stats);
+                	
+                	msleep(delay, false);
+
+                	free(encoded_message);
+                	--count;
                 }
-                else {
-                    state = setup_handlers_and_transmit(tx, fd);
-                    msleep(delay, false);
-                }
-                --count;
+            }
+            else {	
+                log_error("Unable to FEC Encode File [%s]", files[i]);	
             }
             close(fd);
+            munmap(file_data, file_size);
         }
     }
-    return state;
+    return stats.tx_state;
 }
 
 

--- a/dxwifi/tx/tx.c
+++ b/dxwifi/tx/tx.c
@@ -156,13 +156,15 @@ void log_tx_stats(dxwifi_tx_stats stats) {
  *
  */
 bool log_frame_stats(dxwifi_tx_frame* frame, dxwifi_tx_stats stats, void* user) {
+    int frame_size = DXWIFI_TX_FRAME_SIZE;
     if(stats.frame_type == DXWIFI_CONTROL_FRAME_NONE) {
         log_debug("Frame: %d - (Read: %ld, Sent: %ld)", stats.data_frame_count, stats.prev_bytes_read, stats.prev_bytes_sent);
     }
     else {
+        frame_size = DXWIFI_FRAME_CONTROL_SIZE;
         log_debug("%s Frame Sent: %d", control_frame_type_to_str(stats.frame_type), stats.prev_bytes_sent);
     }
-    log_hexdump(frame, DXWIFI_TX_FRAME_SIZE);
+    log_hexdump(frame, frame_size);
     return true;
 }
 

--- a/libdxwifi/details/crc32.h
+++ b/libdxwifi/details/crc32.h
@@ -45,12 +45,10 @@ static const uint32_t crctable[] = {
     0xbdbdf21cL, 0xcabac28aL, 0x53b39330L, 0x24b4a3a6L, 0xbad03605L, 0xcdd70693L, 0x54de5729L, 0x23d967bfL,
     0xb3667a2eL, 0xc4614ab8L, 0x5d681b02L, 0x2a6f2b94L, 0xb40bbe37L, 0xc30c8ea1L, 0x5a05df1bL, 0x2d02ef8dL};
 
-uint32_t crc32(const uint8_t *bytes, uint32_t bytes_sz)
-{
+static uint32_t crc32(const uint8_t *bytes, uint32_t bytes_sz) {
     uint32_t crc = ~0;
     uint32_t i;
-    for (i = 0; i < bytes_sz; ++i)
-    {
+    for (i = 0; i < bytes_sz; ++i) {
         crc = crctable[(crc ^ bytes[i]) & 0xff] ^ (crc >> 8);
     }
     return ~crc;

--- a/libdxwifi/dxwifi.h
+++ b/libdxwifi/dxwifi.h
@@ -41,6 +41,7 @@
  */
 typedef enum {
     DXWIFI_CONTROL_FRAME_NONE       = 0x00,
+    DXWIFI_CONTROL_FRAME_UNKNOWN    = 0x01,
     DXWIFI_CONTROL_FRAME_PREAMBLE   = 0xff,
     DXWIFI_CONTROL_FRAME_EOT        = 0xaa
 } dxwifi_control_frame_t;

--- a/libdxwifi/dxwifi.h
+++ b/libdxwifi/dxwifi.h
@@ -31,7 +31,7 @@
 
 #define DXWIFI_FRAME_CONTROL_SIZE 256
 
-#define DXWIFI_DFLT_SENDER_ADDR { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
+#define DXWIFI_DFLT_SENDER_ADDR { 0xF1, 0xF1, 0xF1, 0xF1, 0xF1, 0xF1 }
 
 /************************
  *  Types

--- a/libdxwifi/dxwifi.h
+++ b/libdxwifi/dxwifi.h
@@ -31,6 +31,8 @@
 
 #define DXWIFI_FRAME_CONTROL_SIZE 256
 
+#define DXWIFI_DFLT_SENDER_ADDR { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }
+
 /************************
  *  Types
  ***********************/

--- a/libdxwifi/dxwifi.h
+++ b/libdxwifi/dxwifi.h
@@ -29,6 +29,8 @@
 
 #define DXWIFI_DFLT_PACKET_BUFFER_TIMEOUT 20
 
+#define DXWIFI_FRAME_CONTROL_SIZE 256
+
 /************************
  *  Types
  ***********************/

--- a/libdxwifi/fec.c
+++ b/libdxwifi/fec.c
@@ -21,8 +21,9 @@
 // Max number of symbols that OpenFEC can handle, 50000
 #define OFEC_MAX_SYMBOLS OF_LDPC_STAIRCASE_MAX_NB_ENCODING_SYMBOLS_DEFAULT
 
-// TODO Add function comments
+#define FEC_PRNG 1804289383
 
+// TODO Add function comments
 static void log_codec_params(const of_ldpc_parameters_t* params) {
     log_info(
         "DxWiFi Codec\n"
@@ -60,7 +61,7 @@ static of_session_t* init_openfec(uint32_t n, uint32_t k, of_codec_type_t type) 
         .nb_source_symbols      = k,
         .nb_repair_symbols      = n - k,
         .encoding_symbol_length = DXWIFI_FEC_SYMBOL_SIZE,
-        .prng_seed              = rand(), // TODO no seed for rand(), does this need to match the decoder?
+        .prng_seed              = FEC_PRNG, 
         .N1                     = (n-k) > DXWIFI_LDPC_N1_MAX ? DXWIFI_LDPC_N1_MAX : (n-k) 
     };
     log_codec_params(&codec_params);
@@ -172,7 +173,6 @@ ssize_t dxwifi_encode(void* message, size_t msglen, float coderate, void** out) 
             void* codeword = &rs_ldpc_frame->blocks[i];
 
             encode_data(message, RSCODE_MAX_MSG_LEN, codeword);
-
         }
         log_ldpc_data_frame(ldpc_frame);
         log_rs_ldpc_data_frame(rs_ldpc_frame);
@@ -239,9 +239,8 @@ ssize_t dxwifi_decode(void* encoded_msg, size_t msglen, void** out) {
         }
 	} 
     if(idx >= nframes){
-        idx = 0;
-        //free(ldpc_frames);
-        //return FEC_ERROR_NO_OTI_FOUND;
+        free(ldpc_frames);
+        return FEC_ERROR_NO_OTI_FOUND;
 	}
 
 	dxwifi_oti* oti = &ldpc_frames[idx].oti;
@@ -267,9 +266,9 @@ ssize_t dxwifi_decode(void* encoded_msg, size_t msglen, void** out) {
     if(!of_is_decoding_complete(openfec_session)) {
         status = of_finish_decoding(openfec_session);
         if(status != OF_STATUS_OK) {
-            free(ldpc_frames);
-            of_release_codec_instance(openfec_session);
-            return FEC_ERROR_DECODE_NOT_POSSIBLE;
+            //free(ldpc_frames);
+            //of_release_codec_instance(openfec_session);
+            //return FEC_ERROR_DECODE_NOT_POSSIBLE;
         }
     }
 

--- a/libdxwifi/fec.c
+++ b/libdxwifi/fec.c
@@ -239,8 +239,9 @@ ssize_t dxwifi_decode(void* encoded_msg, size_t msglen, void** out) {
         }
 	} 
     if(idx >= nframes){
-        free(ldpc_frames);
-        return FEC_ERROR_NO_OTI_FOUND;
+        idx = 0;
+        //free(ldpc_frames);
+        //return FEC_ERROR_NO_OTI_FOUND;
 	}
 
 	dxwifi_oti* oti = &ldpc_frames[idx].oti;

--- a/libdxwifi/fec.c
+++ b/libdxwifi/fec.c
@@ -266,9 +266,9 @@ ssize_t dxwifi_decode(void* encoded_msg, size_t msglen, void** out) {
     if(!of_is_decoding_complete(openfec_session)) {
         status = of_finish_decoding(openfec_session);
         if(status != OF_STATUS_OK) {
-            //free(ldpc_frames);
-            //of_release_codec_instance(openfec_session);
-            //return FEC_ERROR_DECODE_NOT_POSSIBLE;
+            free(ldpc_frames);
+            of_release_codec_instance(openfec_session);
+            return FEC_ERROR_DECODE_NOT_POSSIBLE;
         }
     }
 

--- a/libdxwifi/receiver.c
+++ b/libdxwifi/receiver.c
@@ -466,7 +466,7 @@ static void process_frame(uint8_t* args, const struct pcap_pkthdr* pkt_stats, co
                 fc->rx_stats.total_caplen           += pkt_stats->caplen;
                 fc->rx_stats.total_payload_size     += payload_size;
                 fc->rx_stats.num_packets_processed  += 1;
-                fc->rx_stats.bad_crcs               += crc_valid ? 0 : 1;
+                fc->rx_stats.bad_crcs               += !crc_valid ? 0 : 1;
                 memcpy(&fc->rx_stats.pkt_stats, pkt_stats, sizeof(struct pcap_pkthdr));
 
                 log_frame_stats(&rx_frame, frame_number, &fc->rx_stats);

--- a/libdxwifi/receiver.c
+++ b/libdxwifi/receiver.c
@@ -411,7 +411,8 @@ static void process_frame(uint8_t* args, const struct pcap_pkthdr* pkt_stats, co
 
     if(verify_sender(frame, fc->rx->sender_addr, fc->rx->max_hamming_dist)) {
 
-        dxwifi_control_frame_t ctrl_frame = check_frame_control(frame, 0.66);
+        //dxwifi_control_frame_t ctrl_frame = check_frame_control(frame, 0.66);
+        dxwifi_control_frame_t ctrl_frame = DXWIFI_CONTROL_FRAME_NONE;
 
         if(ctrl_frame != DXWIFI_CONTROL_FRAME_NONE) {
             handle_frame_control(fc, ctrl_frame);

--- a/libdxwifi/receiver.c
+++ b/libdxwifi/receiver.c
@@ -437,7 +437,7 @@ static void process_frame(uint8_t* args, const struct pcap_pkthdr* pkt_stats, co
 
             ssize_t payload_size = rx_frame.fcs - rx_frame.payload;
             if(payload_size != DXWIFI_TX_PAYLOAD_SIZE) {
-                log_warning("Payload size does not match expected: %u / %u", payload_size, DXWIFI_TX_PAYLOAD_SIZE);
+                log_warning("Payload size does not match expected: %d / %d", payload_size, DXWIFI_TX_PAYLOAD_SIZE);
             }
 
             int32_t frame_number = (fc->rx->ordered 

--- a/libdxwifi/receiver.h
+++ b/libdxwifi/receiver.h
@@ -129,7 +129,7 @@ typedef struct {
     .add_noise          = false,\
     .noise_value        = 0xff,\
     .sender_addr        = {0xAA, 0xAA ,0xAA, 0xAA, 0xAA, 0xAA },\
-    .max_hamming_dist   = 10,\
+    .max_hamming_dist   = 5,\
     .filter             = NULL,\
     .optimize           = true,\
     .snaplen            = DXWIFI_SNAPLEN_MAX,\

--- a/libdxwifi/receiver.h
+++ b/libdxwifi/receiver.h
@@ -56,12 +56,12 @@ typedef enum {
  * 
  */
 typedef struct {
-    ieee80211_radiotap_hdr  *rtap_hdr;  /* packed radiotap header       */
-    ieee80211_hdr           *mac_hdr;   /* link-layer header            */
-    uint8_t                 *payload;   /* packet data                  */
-    uint8_t                 *fcs;       /* frame check sequence         */
+    const ieee80211_radiotap_hdr  *rtap_hdr;  /* packed radiotap header       */
+    const ieee80211_hdr           *mac_hdr;   /* link-layer header            */
+    const uint8_t                 *payload;   /* packet data                  */
+    const uint8_t                 *fcs;       /* frame check sequence         */
 
-    uint8_t                 *__frame;   /* storage for the data         */
+    const uint8_t                 *__frame;   /* storage for the data         */
 } dxwifi_rx_frame;
 
 

--- a/libdxwifi/receiver.h
+++ b/libdxwifi/receiver.h
@@ -77,6 +77,7 @@ typedef struct {
     uint32_t                total_noise_added;      /* Number of bytes of noise added   */
     uint32_t                num_packets_processed;  /* Number of packets processed      */
     uint32_t                packets_dropped;        /* Packets dropped because by rx    */
+    uint32_t                bad_crcs;               /* Number of packets with a bad CRC */
     dxwifi_rx_state_t       capture_state;          /* State of last capture            */
     struct pcap_pkthdr      pkt_stats;              /* Stats for the current capture    */
     struct pcap_stat        pcap_stats;             /* Pcap statistics                  */

--- a/libdxwifi/receiver.h
+++ b/libdxwifi/receiver.h
@@ -128,7 +128,7 @@ typedef struct {
     .ordered            = false,\
     .add_noise          = false,\
     .noise_value        = 0xff,\
-    .sender_addr        = {0xAA, 0xAA ,0xAA, 0xAA, 0xAA, 0xAA },\
+    .sender_addr        = DXWIFI_DFLT_SENDER_ADDR,\
     .max_hamming_dist   = 5,\
     .filter             = NULL,\
     .optimize           = true,\

--- a/libdxwifi/receiver.h
+++ b/libdxwifi/receiver.h
@@ -129,7 +129,7 @@ typedef struct {
     .add_noise          = false,\
     .noise_value        = 0xff,\
     .sender_addr        = {0xAA, 0xAA ,0xAA, 0xAA, 0xAA, 0xAA },\
-    .max_hamming_dist   = 20,\
+    .max_hamming_dist   = 10,\
     .filter             = NULL,\
     .optimize           = true,\
     .snaplen            = DXWIFI_SNAPLEN_MAX,\

--- a/libdxwifi/transmitter.c
+++ b/libdxwifi/transmitter.c
@@ -92,9 +92,8 @@ static void construct_ieee80211_header( ieee80211_hdr* mac, ieee80211_frame_cont
 
     mac->duration_id = htons(duration_id);
 
-    memcpy(mac->addr1, sender_address, IEEE80211_MAC_ADDR_LEN);
-    memcpy(mac->addr2, sender_address, IEEE80211_MAC_ADDR_LEN);
-    memcpy(mac->addr3, sender_address, IEEE80211_MAC_ADDR_LEN);
+    memset(mac->addr1, 0xff, IEEE80211_MAC_ADDR_LEN);
+    memset(mac->addr3, 0xff, IEEE80211_MAC_ADDR_LEN);
 
     // Note to future developers, for some reason if the first two bytes of 
     // addr1 are 0x00 then the ath9k_htc driver will attempt to retransmit the
@@ -102,6 +101,8 @@ static void construct_ieee80211_header( ieee80211_hdr* mac, ieee80211_frame_cont
     // go down the hours-long rabbit hole of figuring out why the transmitter is
     // broken after the seemingly innocuous change of modifying the address field
     debug_assert(mac->addr1[0] && mac->addr1[1]);
+
+    memcpy(mac->addr2, sender_address, IEEE80211_MAC_ADDR_LEN);
 
     mac->seq_ctrl = 0;
 }

--- a/libdxwifi/transmitter.c
+++ b/libdxwifi/transmitter.c
@@ -92,8 +92,9 @@ static void construct_ieee80211_header( ieee80211_hdr* mac, ieee80211_frame_cont
 
     mac->duration_id = htons(duration_id);
 
-    memset(mac->addr1, 0xff, IEEE80211_MAC_ADDR_LEN);
-    memset(mac->addr3, 0xff, IEEE80211_MAC_ADDR_LEN);
+    memcpy(mac->addr1, sender_address, IEEE80211_MAC_ADDR_LEN);
+    memcpy(mac->addr2, sender_address, IEEE80211_MAC_ADDR_LEN);
+    memcpy(mac->addr3, sender_address, IEEE80211_MAC_ADDR_LEN);
 
     // Note to future developers, for some reason if the first two bytes of 
     // addr1 are 0x00 then the ath9k_htc driver will attempt to retransmit the
@@ -102,7 +103,6 @@ static void construct_ieee80211_header( ieee80211_hdr* mac, ieee80211_frame_cont
     // broken after the seemingly innocuous change of modifying the address field
     debug_assert(mac->addr1[0] && mac->addr1[1]);
 
-    memcpy(mac->addr2, sender_address, IEEE80211_MAC_ADDR_LEN);
 
     mac->seq_ctrl = 0;
 }

--- a/libdxwifi/transmitter.h
+++ b/libdxwifi/transmitter.h
@@ -209,7 +209,7 @@ typedef struct {
         .wep                = false,\
         .order              = false\
     },\
-    .address = {0xAA, 0xAA ,0xAA, 0xAA, 0xAA, 0xAA },\
+    .address = DXWIFI_DFLT_SENDER_ADDR,\
 }\
 
 

--- a/test/test_tx_rx.py
+++ b/test/test_tx_rx.py
@@ -248,12 +248,11 @@ class TestTxRx(unittest.TestCase):
         tx_out      = f'{TEMP_DIR}/tx.raw'
         rx_out      = f'{TEMP_DIR}/rx.raw'
 
-        tx_command = f'{TX} {test_file} -q --error-rate 0.003 --savefile {tx_out}'
+        tx_command = f'{TX} {test_file} -q --error-rate 0.004 --savefile {tx_out}'
         rx_command = f'{RX} {rx_out} -q -t 2 --savefile {tx_out}'
 
         # Create a single test file
         genbytes(test_file, 10, FEC_SYMBOL_SIZE) # Create test file
-
 
         # Transmit the test file
         subprocess.run(tx_command.split()).check_returncode()
@@ -273,7 +272,7 @@ class TestTxRx(unittest.TestCase):
         tx_out      = f'{TEMP_DIR}/tx.raw'
         rx_out      = f'{TEMP_DIR}/rx.raw'
 
-        tx_command = f'{TX} {test_file} -q --packet-loss 0.05 --savefile {tx_out}'
+        tx_command = f'{TX} {test_file} -q --packet-loss 0.1 --savefile {tx_out}'
         rx_command = f'{RX} {rx_out} -q --savefile {tx_out}'
 
         # Create a single test file
@@ -297,7 +296,7 @@ class TestTxRx(unittest.TestCase):
         tx_out      = f'{TEMP_DIR}/tx.raw'
         rx_out      = f'{TEMP_DIR}/rx.raw'
 
-        tx_command = f'{TX} {test_file} -q --packet-loss 0.05 --error-rate 0.003 --savefile {tx_out}'
+        tx_command = f'{TX} {test_file} -q --packet-loss 0.1 --error-rate 0.004 --savefile {tx_out}'
         rx_command = f'{RX} {rx_out} -q --savefile {tx_out}'
 
         # Create a single test file

--- a/test/test_tx_rx.py
+++ b/test/test_tx_rx.py
@@ -254,6 +254,7 @@ class TestTxRx(unittest.TestCase):
         # Create a single test file
         genbytes(test_file, 10, FEC_SYMBOL_SIZE) # Create test file
 
+
         # Transmit the test file
         subprocess.run(tx_command.split()).check_returncode()
 


### PR DESCRIPTION
This PR is kind of a monolith. Not how I usually like to do things but I'm running short on time with my other obligations and I didn't get around to separating everything into different branches 😭 . 

So here it is. PR fixes #18 , #46, fixes a number of bugs and tweaks parameters, such that `tx`/`rx` works on the actual hardware again 🎉  

- Adds CRC check to `process_frame()` in the receiver. We don't do anything with this information except for log the number of packets with bad CRCs after capture. 
- Adds three new test cases testing bit errors, packet loss, and both packet loss and bit errors. In an effort to keep things deterministic, a constant seed was also added for the RNG in test mode. 
- Fix tempfile not truncating data during multi-file transmission
- Fix `rx` always reporting decode success even on failure
- Fix Control frames being processed as regular data frames, which was causing a ton of issues with the receiver.
- Fix FEC PRNG being incorrect on different devices causing the LDPC decoding to fail.
- Fix receiver processing data frames that would cause misalignment for the decoder. 
- Fix hamming distance being way too high, causing the receiver to pick up network traffic not from the transmitter.
- Fix the sender address causing the MAC drivers to interpret received packets as multicast packets which was causing all received packets to be processed in 53 byte chunks. 
- Added static declaration to crc32() which was causing build errors when crc32.h was included in multiple files. 