### PR TITLE
Dirwatch fixes

### DIFF
--- a/libdxwifi/details/dirwatch.c
+++ b/libdxwifi/details/dirwatch.c
@@ -320,7 +320,7 @@ void dirwatch_listen(dirwatch* dw, int timeout_ms, dirwatch_event_handler handle
                         bool found = false;
                         for(int i = 0; i < DIRWATCH_MAX && !found; ++i) {
                             // TODO: strcmp in linear search is sub-optimal at best
-                            if(dir->watchfiles[i] && strcmp(event->name, dir->watchfiles[i]) == 0) {
+                            if(dir->watchfiles[i] && (strcmp(event->name, dir->watchfiles[i]) == 0)) {
                                 log_debug("File closed: %s", event->name);
 
                                 dw_event.event    = DW_CREATE_AND_CLOSE;

--- a/libdxwifi/details/dirwatch.c
+++ b/libdxwifi/details/dirwatch.c
@@ -298,11 +298,16 @@ void dirwatch_listen(dirwatch* dw, int timeout_ms, dirwatch_event_handler handle
 
                     // Cache the filename if it matches the filter
                     if(dir && fnmatch(dir->file_filter, event->name, 0) == 0) {
-                        for(int i = 0; i < DIRWATCH_MAX; ++i) { // Find an empty watchfile
+                        bool added = false;
+                        for(int i = 0; i < DIRWATCH_MAX && !added; ++i) { // Find an empty watchfile
                             if(dir->watchfiles[i] == NULL){
                                 log_debug("File created: %s", event->name);
                                 dir->watchfiles[i] = strdup(event->name);
+                                added = true;
                             }
+                        }
+                        if(!added) {
+                            log_warning("Failed to add newly created file `%s` to watchlist", event->name);
                         }
                     }
                 }

--- a/libdxwifi/details/dirwatch.c
+++ b/libdxwifi/details/dirwatch.c
@@ -294,13 +294,13 @@ void dirwatch_listen(dirwatch* dw, int timeout_ms, dirwatch_event_handler handle
 
                 // New file was created, watch for file close
                 if((event->mask & IN_CREATE) && !(event->mask & IN_ISDIR)) {
-
                     watchdir* dir = find_watchdir(dw, &event->wd, find_by_wd);
 
                     // Cache the filename if it matches the filter
                     if(dir && fnmatch(dir->file_filter, event->name, 0) == 0) {
                         for(int i = 0; i < DIRWATCH_MAX; ++i) { // Find an empty watchfile
                             if(dir->watchfiles[i] == NULL){
+                                log_debug("File created: %s", event->name);
                                 dir->watchfiles[i] = strdup(event->name);
                             }
                         }
@@ -315,7 +315,9 @@ void dirwatch_listen(dirwatch* dw, int timeout_ms, dirwatch_event_handler handle
                         bool found = false;
                         for(int i = 0; i < DIRWATCH_MAX && !found; ++i) {
                             // TODO: strcmp in linear search is sub-optimal at best
-                            if(strcmp(event->name, dir->watchfiles[i]) == 0) {
+                            if(dir->watchfiles[i] && strcmp(event->name, dir->watchfiles[i]) == 0) {
+                                log_debug("File closed: %s", event->name);
+
                                 dw_event.event    = DW_CREATE_AND_CLOSE;
                                 dw_event.dirname  = dir->dirname;
                                 dw_event.filename = dir->watchfiles[i];


### PR DESCRIPTION
PR fixes a few unnoticed bugs in the `dirwatch` system.

- Fixes segfault when a watchfile is removed
- Fixes issue where we add a file to the watchlist multiple times
- Adds debugging log statements
