### PR TITLE
Remove FCS handling

### DIFF
--- a/dxwifi/tx/cli.c
+++ b/dxwifi/tx/cli.c
@@ -82,7 +82,7 @@ static struct argp_option opts[] = {
     { "short-preamble", GET_KEY(IEEE80211_RADIOTAP_F_SHORTPRE,      RTAP_FLAGS_GROUP),      0,          OPTION_NO_USAGE,  "Sent with short preamble",               RTAP_FLAGS_GROUP },
     { "wep",            GET_KEY(IEEE80211_RADIOTAP_F_WEP,           RTAP_FLAGS_GROUP),      0,          OPTION_NO_USAGE,  "Sent with WEP encryption",               RTAP_FLAGS_GROUP },
     { "frag",           GET_KEY(IEEE80211_RADIOTAP_F_FRAG,          RTAP_FLAGS_GROUP),      0,          OPTION_NO_USAGE,  "Sent with fragmentation",                RTAP_FLAGS_GROUP },
-    { "nofcs",          GET_KEY(IEEE80211_RADIOTAP_F_FCS,           RTAP_FLAGS_GROUP),      0,          OPTION_NO_USAGE,  "Frame does not includes FCS",            RTAP_FLAGS_GROUP },
+    { "fcs",            GET_KEY(IEEE80211_RADIOTAP_F_FCS,           RTAP_FLAGS_GROUP),      0,          OPTION_NO_USAGE,  "Frame includes an FCS",                  RTAP_FLAGS_GROUP },
     { "ack",            GET_KEY(IEEE80211_RADIOTAP_F_TX_NOACK,      RTAP_TX_FLAGS_GROUP),   0,          OPTION_NO_USAGE,  "Tx expects an ACK frame",                RTAP_TX_FLAGS_GROUP },
     { "sequence",       GET_KEY(IEEE80211_RADIOTAP_F_TX_NOSEQNO,    RTAP_TX_FLAGS_GROUP),   0,          OPTION_NO_USAGE,  "Tx includes preconfigured sequence id",  RTAP_TX_FLAGS_GROUP },
     { "ordered",        GET_KEY(IEEE80211_RADIOTAP_F_TX_ORDER,      RTAP_TX_FLAGS_GROUP),   0,          OPTION_NO_USAGE,  "Tx should not be reordered",             RTAP_TX_FLAGS_GROUP },

--- a/libdxwifi/receiver.c
+++ b/libdxwifi/receiver.c
@@ -482,7 +482,12 @@ static void process_frame(uint8_t* args, const struct pcap_pkthdr* pkt_stats, co
     if(verify_sender(frame, fc->rx->sender_addr, fc->rx->max_hamming_dist)) {
         dxwifi_control_frame_t ctrl_frame = check_frame_control(frame, pkt_stats, 0.66);
 
-        if(ctrl_frame != DXWIFI_CONTROL_FRAME_NONE) {
+        if(ctrl_frame == DXWIFI_CONTROL_FRAME_UNKNOWN) {
+            // Payload size is incorrect, log the frame but don't process it
+            log_warning("caplen: %d, len: %d", pkt_stats->caplen, pkt_stats->len);
+            log_hexdump(frame, pkt_stats->caplen);
+        }
+        else if(ctrl_frame != DXWIFI_CONTROL_FRAME_NONE) {
             handle_frame_control(fc, ctrl_frame);
         }
         else {

--- a/libdxwifi/transmitter.c
+++ b/libdxwifi/transmitter.c
@@ -224,7 +224,7 @@ static int inject_packet(dxwifi_transmitter* tx, dxwifi_tx_frame* frame, dxwifi_
 
     size_t frame_size = DXWIFI_TX_FRAME_SIZE;
     if(stats->frame_type != DXWIFI_CONTROL_FRAME_NONE) {
-        frame_size = DXWIFI_TX_HEADER_SIZE + DXWIFI_FRAME_CONTROL_SIZE + IEEE80211_FCS_SIZE;
+        frame_size = DXWIFI_TX_HEADER_SIZE + DXWIFI_FRAME_CONTROL_SIZE;
     }
 
     if(transmit) {

--- a/libdxwifi/transmitter.h
+++ b/libdxwifi/transmitter.h
@@ -37,7 +37,7 @@
 #define DXWIFI_TX_BLOCKSIZE DXWIFI_TX_PAYLOAD_SIZE
 
 #define DXWIFI_TX_FRAME_SIZE \
-    (DXWIFI_TX_HEADER_SIZE + DXWIFI_TX_PAYLOAD_SIZE + IEEE80211_FCS_SIZE)
+    (DXWIFI_TX_HEADER_SIZE + DXWIFI_TX_PAYLOAD_SIZE)
 
 #define DXWIFI_TX_RADIOTAP_PRESENCE_BIT_FIELD \
     ( 0x1 << IEEE80211_RADIOTAP_FLAGS    \
@@ -93,8 +93,8 @@ typedef struct __attribute__((packed)) {
     // Actual Data Frame
     dxwifi_tx_radiotap_hdr  radiotap_hdr;  /* frame metadata               */
     ieee80211_hdr           mac_hdr;       /* link-layer header            */
-    uint8_t                 payload[DXWIFI_TX_PAYLOAD_SIZE + IEEE80211_FCS_SIZE];       
-                                            /* packet data and FCS          */
+    uint8_t                 payload[DXWIFI_TX_PAYLOAD_SIZE];       
+                                           /* packet data, driver attaches FCS */
 } dxwifi_tx_frame;
 compiler_assert(sizeof(dxwifi_tx_frame) == DXWIFI_TX_FRAME_SIZE, 
     "Mismatch in actual tx frame size and calculated size");
@@ -194,7 +194,7 @@ typedef struct {
     .transmit_timeout       = -1,\
     .redundant_ctrl_frames  = 0,\
     .enable_pa              = false,\
-    .rtap_flags             = IEEE80211_RADIOTAP_F_FCS,\
+    .rtap_flags             = 0x00,\
     .rtap_rate_mbps         = 1,\
     .rtap_tx_flags          = IEEE80211_RADIOTAP_F_TX_NOACK,\
     .fctl = {\


### PR DESCRIPTION
Issue #61 highlighted an issue where the last four bytes of payload data was being replaced with the FCS. This was happening because the radiotap FCS flag 0x10 was set by default. In previous driver versions this flag appeared direct the driver to use the last four bytes of the packet for the FCS, now it appears to have a different effect. This PR pulls in a fix that removes FCS handling from the transmitter and does not set the FCS radiotap flag. The effect is that now the driver will attach the FCS bytes to the end of our packet instead of overwriting our data.  

Closes #61 