### PR TITLE
Fix: receiver: Prevent hang in rx

### DIFF
--- a/libdxwifi/receiver.c
+++ b/libdxwifi/receiver.c
@@ -296,7 +296,6 @@ static void handle_frame_control(frame_controller* fc, dxwifi_control_frame_t ty
         if(fc->rx_stats.num_packets_processed > 0) {
             // Somehow we have run into the next files capture.
             fc->end_capture = true;
-            //pcap_breakloop(fc->rx->__handle);
         }
         else if(!fc->preamble_recv){
             log_info("Uplink established!");
@@ -307,8 +306,7 @@ static void handle_frame_control(frame_controller* fc, dxwifi_control_frame_t ty
     case DXWIFI_CONTROL_FRAME_EOT:
         if(!fc->eot_reached) {
             log_info("End-Of-Transmission signalled");
-            //fc->end_capture = true;
-            //pcap_breakloop(fc->rx->__handle);
+            fc->end_capture = true;
         }
         fc->eot_reached = true;
         break;


### PR DESCRIPTION
As of commit 3752bb5e, rx hangs forever after receiving an end-of-transmission signal in a live capture.

pcap_dispatch() returns after it finishes processing rx->dispatch_count packets or the current bufferful of packets. However, because rx->__activated is still true and fc->end_capture is still false, we re-enter the while loop in receiver_activate_capture(). We then poll again instead of returning. We continue waiting until we receive another packet or reach the capture timeout.

receiver_activate_capture() can likely benefit from additional changes, but this seems like a step in the right direction.

Fixes #74 