### PR TITLE
Revert "Fix: receiver: Prevent hang in rx"

### DIFF
--- a/libdxwifi/receiver.c
+++ b/libdxwifi/receiver.c
@@ -296,6 +296,7 @@ static void handle_frame_control(frame_controller* fc, dxwifi_control_frame_t ty
         if(fc->rx_stats.num_packets_processed > 0) {
             // Somehow we have run into the next files capture.
             fc->end_capture = true;
+            //pcap_breakloop(fc->rx->__handle);
         }
         else if(!fc->preamble_recv){
             log_info("Uplink established!");
@@ -306,7 +307,8 @@ static void handle_frame_control(frame_controller* fc, dxwifi_control_frame_t ty
     case DXWIFI_CONTROL_FRAME_EOT:
         if(!fc->eot_reached) {
             log_info("End-Of-Transmission signalled");
-            fc->end_capture = true;
+            //fc->end_capture = true;
+            //pcap_breakloop(fc->rx->__handle);
         }
         fc->eot_reached = true;
         break;


### PR DESCRIPTION
This reverts commit f692013a87f027bf084f6c6d14d4b1ac6fb8dd14.

That commit fixed an issue with single-file rx but broke multi-file rx, which is the use case we envision for production.